### PR TITLE
Bug 1209041 - [ignore-dir] attribute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ By default the gaia-header component assumes that it is flush with the `window` 
 
 Prevents font-fit logic from running. Will run when the attribute is removed. You may choose to use this for app specific performance optimizations.
 
+### `ignore-dir`
+
+```html
+<gaia-header action="back" ignore-dir>
+  <h1>title</h1>
+</gaia-header>
+```
+
+Force the older behavior of gaia-header, where the whole header is always displayed in LTR mode.
+
 ### Localization
 
 If choosing to use the built in action-button you may wish to localize the content within. You can do this by providing a special `l10n-action` child node. This node will be 'distributed' inside the action-button acting as `textContent` for screen-readers.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-header",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "homepage": "https://github.com/gaia-components/gaia-header",
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
@@ -18,7 +18,7 @@
     "README.md"
   ],
   "dependencies": {
-    "gaia-icons": "gaia-components/gaia-icons#~0.8.0",
+    "gaia-icons": "gaia-components/gaia-icons#~0.10.0",
     "gaia-component": "gaia-components/gaia-component#~0.4.0",
     "font-fit": "gaia-components/font-fit#~0.3.0"
   },

--- a/dist/gaia-header-es5.js
+++ b/dist/gaia-header-es5.js
@@ -30,7 +30,7 @@
   })({ 1: [function (require, module, exports) {
       ;(function (define) {
         define(function (require, exports, module) {
-          "use strict";
+          'use strict';
 
           /**
            * Simple logger.
@@ -85,7 +85,7 @@
            * @return {Object} {fontSize,overflowing,textWidth}
            */
           module.exports = function (config) {
-            debug("font fit", config);
+            debug('font fit', config);
             var space = config.space - BUFFER;
             var min = config.min || MIN;
             var max = config.max || MAX;
@@ -95,7 +95,7 @@
             var font;
 
             do {
-              font = config.font.replace(/\d+px/, fontSize + "px");
+              font = config.font.replace(/\d+px/, fontSize + 'px');
               textWidth = getTextWidth(text, font);
             } while (textWidth > space && fontSize !== min && fontSize--);
 
@@ -117,7 +117,7 @@
           function getTextWidth(text, font) {
             var ctx = getCanvasContext(font);
             var width = ctx.measureText(text).width;
-            debug("got text width", width);
+            debug('got text width', width);
             return width;
           }
 
@@ -129,20 +129,20 @@
            * @return {CanvasRenderingContext2D}
            */
           function getCanvasContext(font) {
-            debug("get canvas context", font);
+            debug('get canvas context', font);
 
             var cached = cache[font];
             if (cached) {
               return cached;
             }
 
-            var canvas = document.createElement("canvas");
-            canvas.setAttribute("moz-opaque", "true");
-            canvas.setAttribute("width", "1px");
-            canvas.setAttribute("height", "1px");
-            debug("created canvas", canvas);
+            var canvas = document.createElement('canvas');
+            canvas.setAttribute('moz-opaque', 'true');
+            canvas.setAttribute('width', '1px');
+            canvas.setAttribute('height', '1px');
+            debug('created canvas', canvas);
 
-            var ctx = canvas.getContext("2d", { willReadFrequently: true });
+            var ctx = canvas.getContext('2d', { willReadFrequently: true });
             ctx.font = font;
 
             return cache[font] = ctx;
@@ -156,27 +156,27 @@
            * @return {String}
            */
           function trim(text) {
-            return text.replace(/\s+/g, " ").trim();
+            return text.replace(/\s+/g, ' ').trim();
           }
         });
-      })(typeof define == "function" && define.amd ? define : (function (n, w) {
-        "use strict";return typeof module == "object" ? function (c) {
+      })(typeof define == 'function' && define.amd ? define : (function (n, w) {
+        'use strict';return typeof module == 'object' ? function (c) {
           c(require, exports, module);
         } : function (c) {
           var m = { exports: {} };c(function (n) {
             return w[n];
           }, m.exports, m);w[n] = m.exports;
         };
-      })("font-fit", this));
+      })('font-fit', this));
     }, {}], 2: [function (require, module, exports) {
       /* globals define */
       ;(function (define) {
-        "use strict";define(function (require, exports, module) {
+        'use strict';define(function (require, exports, module) {
           /**
            * Locals
            */
-          var textContent = Object.getOwnPropertyDescriptor(Node.prototype, "textContent");
-          var innerHTML = Object.getOwnPropertyDescriptor(Element.prototype, "innerHTML");
+          var textContent = Object.getOwnPropertyDescriptor(Node.prototype, 'textContent');
+          var innerHTML = Object.getOwnPropertyDescriptor(Element.prototype, 'innerHTML');
           var removeAttribute = Element.prototype.removeAttribute;
           var setAttribute = Element.prototype.setAttribute;
           var noop = function noop() {};
@@ -196,7 +196,7 @@
             // Components are extensible by default but can be declared
             // as non extensible as an optimization to avoid
             // storing the template strings
-            var extensible = props.extensible = props.hasOwnProperty("extensible") ? props.extensible : true;
+            var extensible = props.extensible = props.hasOwnProperty('extensible') ? props.extensible : true;
 
             // Clean up
             delete props["extends"];
@@ -211,11 +211,11 @@
 
               var output = processCss(template, name);
 
-              props.template = document.createElement("template");
+              props.template = document.createElement('template');
               props.template.innerHTML = output.template;
               props.lightCss = output.lightCss;
 
-              props.globalCss = props.globalCss || "";
+              props.globalCss = props.globalCss || '';
               props.globalCss += output.globalCss;
             }
 
@@ -242,7 +242,7 @@
             try {
               return document.registerElement(name, { prototype: proto });
             } catch (e) {
-              if (e.name !== "NotSupportedError") {
+              if (e.name !== 'NotSupportedError') {
                 throw e;
               }
             }
@@ -294,14 +294,14 @@
               attachedCallback: function attachedCallback() {
                 if (this.dirObserver) {
                   this.setInnerDirAttributes = setInnerDirAttributes.bind(null, this);
-                  document.addEventListener("dirchanged", this.setInnerDirAttributes);
+                  document.addEventListener('dirchanged', this.setInnerDirAttributes);
                 }
                 this.attached();
               },
 
               detachedCallback: function detachedCallback() {
                 if (this.dirObserver) {
-                  document.removeEventListener("dirchanged", this.setInnerDirAttributes);
+                  document.removeEventListener('dirchanged', this.setInnerDirAttributes);
                 }
                 this.detached();
               },
@@ -427,9 +427,9 @@
            * @return {Boolean}
            */
           var hasShadowCSS = (function () {
-            var div = document.createElement("div");
+            var div = document.createElement('div');
             try {
-              div.querySelector(":host");return true;
+              div.querySelector(':host');return true;
             } catch (e) {
               return false;
             }
@@ -442,10 +442,10 @@
            */
           var regex = {
             shadowCss: /(?:\:host|\:\:content)[^{]*\{[^}]*\}/g,
-            ":host": /(?:\:host)/g,
-            ":host()": /\:host\((.+)\)(?: \:\:content)?/g,
-            ":host-context": /\:host-context\((.+)\)([^{,]+)?/g,
-            "::content": /(?:\:\:content)/g
+            ':host': /(?:\:host)/g,
+            ':host()': /\:host\((.+)\)(?: \:\:content)?/g,
+            ':host-context': /\:host-context\((.+)\)([^{,]+)?/g,
+            '::content': /(?:\:\:content)/g
           };
 
           /**
@@ -458,20 +458,20 @@
            * @return {String}
            */
           function processCss(template, name) {
-            var globalCss = "";
-            var lightCss = "";
+            var globalCss = '';
+            var lightCss = '';
 
             if (!hasShadowCSS) {
               template = template.replace(regex.shadowCss, function (match) {
-                var hostContext = regex[":host-context"].exec(match);
+                var hostContext = regex[':host-context'].exec(match);
 
                 if (hostContext) {
-                  globalCss += match.replace(regex["::content"], "").replace(regex[":host-context"], "$1 " + name + "$2").replace(/ +/g, " "); // excess whitespace
+                  globalCss += match.replace(regex['::content'], '').replace(regex[':host-context'], '$1 ' + name + '$2').replace(/ +/g, ' '); // excess whitespace
                 } else {
-                  lightCss += match.replace(regex[":host()"], name + "$1").replace(regex[":host"], name).replace(regex["::content"], name);
-                }
+                    lightCss += match.replace(regex[':host()'], name + '$1').replace(regex[':host'], name).replace(regex['::content'], name);
+                  }
 
-                return "";
+                return '';
               });
             }
 
@@ -497,7 +497,7 @@
             if (!css) {
               return;
             }
-            var style = document.createElement("style");
+            var style = document.createElement('style');
             style.innerHTML = css.trim();
             headReady().then(function () {
               document.head.appendChild(style);
@@ -514,8 +514,8 @@
               if (document.head) {
                 return resolve();
               }
-              window.addEventListener("load", function fn() {
-                window.removeEventListener("load", fn);
+              window.addEventListener('load', function fn() {
+                window.removeEventListener('load', fn);
                 resolve();
               });
             });
@@ -539,11 +539,11 @@
             if (hasShadowCSS) {
               return;
             }
-            var stylesheet = el.querySelector("style");
+            var stylesheet = el.querySelector('style');
 
             if (!stylesheet) {
-              stylesheet = document.createElement("style");
-              stylesheet.setAttribute("scoped", "");
+              stylesheet = document.createElement('style');
+              stylesheet.setAttribute('scoped', '');
               stylesheet.appendChild(document.createTextNode(el.lightCss));
               el.appendChild(stylesheet);
             }
@@ -592,7 +592,7 @@
           function setInnerDirAttributes(component) {
             var dir = component.dir || document.dir;
             Array.from(component.shadowRoot.children).forEach(function (element) {
-              if (element.nodeName !== "STYLE") {
+              if (element.nodeName !== 'STYLE') {
                 element.dir = dir;
               }
             });
@@ -614,12 +614,12 @@
 
             dirObserver = new MutationObserver(onChanged);
             dirObserver.observe(document.documentElement, {
-              attributeFilter: ["dir"],
+              attributeFilter: ['dir'],
               attributes: true
             });
 
             function onChanged(mutations) {
-              document.dispatchEvent(new Event("dirchanged"));
+              document.dispatchEvent(new Event('dirchanged'));
             }
           }
 
@@ -640,28 +640,28 @@
             return target;
           }
         });
-      })(typeof define == "function" && define.amd ? define : (function (n, w) {
-        "use strict";return typeof module == "object" ? function (c) {
+      })(typeof define == 'function' && define.amd ? define : (function (n, w) {
+        'use strict';return typeof module == 'object' ? function (c) {
           c(require, exports, module);
         } : function (c) {
           var m = { exports: {} };c(function (n) {
             return w[n];
           }, m.exports, m);w[n] = m.exports;
         };
-      })("gaia-component", this));
+      })('gaia-component', this));
     }, {}], 3: [function (require, module, exports) {
+      /* global define */
       (function (define) {
-        define(function (require, exports, module) {
-          /*jshint laxbreak:true*/
+        'use strict';define(function (require, exports, module) {
 
           /**
            * Exports
            */
 
-          var base = window.GAIA_ICONS_BASE_URL || window.COMPONENTS_BASE_URL || "bower_components/";
+          var base = window.GAIA_ICONS_BASE_URL || window.COMPONENTS_BASE_URL || 'bower_components/';
 
           if (!document.documentElement) {
-            window.addEventListener("load", load);
+            window.addEventListener('load', load);
           } else {
             load();
           }
@@ -671,42 +671,42 @@
               return;
             }
 
-            var link = document.createElement("link");
-            link.rel = "stylesheet";
-            link.type = "text/css";
-            link.href = base + "gaia-icons/gaia-icons.css";
+            var link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.type = 'text/css';
+            link.href = base + 'gaia-icons/gaia-icons.css';
             document.head.appendChild(link);
             exports.loaded = true;
           }
 
           function isLoaded() {
-            return exports.loaded || document.querySelector("link[href*=gaia-icons]") || document.documentElement.classList.contains("gaia-icons-loaded");
+            return exports.loaded || document.querySelector('link[href*=gaia-icons]') || document.documentElement.classList.contains('gaia-icons-loaded');
           }
         });
-      })(typeof define == "function" && define.amd ? define : (function (n, w) {
-        return typeof module == "object" ? function (c) {
+      })(typeof define == 'function' && define.amd ? define : (function (n, w) {
+        'use strict';return typeof module == 'object' ? function (c) {
           c(require, exports, module);
         } : function (c) {
           var m = { exports: {} };c(function (n) {
             return w[n];
           }, m.exports, m);w[n] = m.exports;
         };
-      })("gaia-icons", this));
+      })('gaia-icons', this));
     }, {}], 4: [function (require, module, exports) {
       /* globals define */
       ;(function (define) {
-        "use strict";define(function (require, exports, module) {
+        'use strict';define(function (require, exports, module) {
 
           /**
            * Dependencies
            */
-          var component = require("gaia-component");
-          var _fontFit = require("font-fit");
+          var component = require('gaia-component');
+          var _fontFit = require('font-fit');
 
           /**
            * Load 'gaia-icons' font-family
            */
-          require("gaia-icons");
+          require('gaia-icons');
 
           /**
            * Simple logger (toggle 0)
@@ -721,9 +721,9 @@
            * @type {Object}
            */
           var KNOWN_ACTIONS = {
-            menu: "menu",
-            back: "back",
-            close: "close"
+            menu: 'menu',
+            back: 'back',
+            close: 'close'
           };
 
           /**
@@ -731,7 +731,7 @@
            *
            * @type {String}
            */
-          var TITLE_FONT = "italic 300 24px FiraSans";
+          var TITLE_FONT = 'italic 300 24px FiraSans';
 
           /**
            * The padding (start/end) used if
@@ -765,7 +765,7 @@
            *
            * @return {Element} constructor
            */
-          module.exports = component.register("gaia-header", {
+          module.exports = component.register('gaia-header', {
             extensible: false, // discards some strings
             dirObserver: true, // triggers a workaround for bug 1100912 in gaia-component
 
@@ -780,27 +780,28 @@
             created: function created() {
               var _this = this;
 
-              debug("created");
+              debug('created');
               this.setupShadowRoot();
 
               // Elements
               this.els = {
-                actionButton: this.shadowRoot.querySelector(".action-button"),
-                titles: this.getElementsByTagName("h1")
+                actionButton: this.shadowRoot.querySelector('.action-button'),
+                titles: this.getElementsByTagName('h1')
               };
 
               // Events
-              this.els.actionButton.addEventListener("click", function (e) {
+              this.els.actionButton.addEventListener('click', function (e) {
                 return _this.onActionButtonClick(e);
               });
               this.observer = new MutationObserver(this.onMutation.bind(this));
 
               // Properties
-              this.titleEnd = this.getAttribute("title-end");
-              this.titleStart = this.getAttribute("title-start");
-              this.noFontFit = this.getAttribute("no-font-fit");
-              this.notFlush = this.hasAttribute("not-flush");
-              this.action = this.getAttribute("action");
+              this.ignoreDir = this.hasAttribute('ignore-dir');
+              this.titleEnd = this.getAttribute('title-end');
+              this.titleStart = this.getAttribute('title-start');
+              this.noFontFit = this.getAttribute('no-font-fit');
+              this.notFlush = this.hasAttribute('not-flush');
+              this.action = this.getAttribute('action');
 
               this.unresolved = {};
               this.pending = {};
@@ -825,10 +826,10 @@
              * @private
              */
             attached: function attached() {
-              debug("attached");
+              debug('attached');
               this.runFontFitSoon();
               this.observerStart();
-              window.addEventListener("resize", this.onResize);
+              window.addEventListener('resize', this.onResize);
             },
 
             /**
@@ -838,8 +839,8 @@
              * @private
              */
             detached: function detached() {
-              debug("detached");
-              window.removeEventListener("resize", this.onResize);
+              debug('detached');
+              window.removeEventListener('resize', this.onResize);
               this.observerStop();
               this.clearPending();
             },
@@ -875,7 +876,7 @@
             runFontFit: function runFontFit() {
               var _this2 = this;
 
-              debug("run font-fit");
+              debug('run font-fit');
 
               // Nothing is run if `no-font-fit` attribute
               // is present. We don't `reject()` as this
@@ -904,7 +905,7 @@
             runFontFitSoon: function runFontFitSoon() {
               var _this3 = this;
 
-              debug("run font-fit soon");
+              debug('run font-fit soon');
               if (this.pending.runFontFitSoon) {
                 return;
               }
@@ -924,19 +925,19 @@
              * @private
              */
             getTitleStyle: function getTitleStyle(el, space) {
-              debug("get el style", el, space);
+              debug('get el style', el, space);
               var text = el.textContent;
-              var styleId = space.start + text + space.end + "#" + space.value;
+              var styleId = space.start + text + space.end + '#' + space.value;
 
               // Bail when there's no text (or just whitespace)
               if (!text || !text.trim()) {
-                return debug("exit: no text");
+                return debug('exit: no text');
               }
 
               // If neither the text or the titleSpace
               // changed, there's no reason to continue.
               if (getStyleId(el) === styleId) {
-                return debug("exit: no change");
+                return debug('exit: no change');
               }
 
               var marginStart = this.getTitleMarginStart();
@@ -953,7 +954,7 @@
               // to free up space, rerun fontFit to
               // get a fontSize which fits this space.
               if (overflowing) {
-                debug("title overflowing");
+                debug('title overflowing');
                 padding.start = !space.start ? TITLE_PADDING : 0;
                 padding.end = !space.end ? TITLE_PADDING : 0;
                 textSpace = space.value - padding.start - padding.end;
@@ -971,7 +972,7 @@
             },
 
             /**
-             * Set's styles on the title elements.
+             * Sets styles on the title elements.
              *
              * If there is already an unresolved Promise
              * we return it instead of scheduling another.
@@ -985,8 +986,8 @@
             setTitleStylesSoon: function setTitleStylesSoon(styles) {
               var _this4 = this;
 
-              debug("set title styles soon", styles);
-              var key = "setStyleTitlesSoon";
+              debug('set title styles soon', styles);
+              var key = 'setStyleTitlesSoon';
 
               // Always update styles
               this._titleStyles = styles;
@@ -1003,7 +1004,7 @@
 
                   [].forEach.call(els, function (el, i) {
                     if (!styles[i]) {
-                      return debug("exit");
+                      return debug('exit');
                     }
                     _this4.setTitleStyle(el, styles[i]);
                   });
@@ -1026,12 +1027,18 @@
              * @private
              */
             setTitleStyle: function setTitleStyle(el, style) {
-              debug("set title style", style);
+              debug('set title style', style);
               this.observerStop();
-              el.style.marginInlineStart = style.marginStart + "px";
-              el.style.paddingInlineStart = style.padding.start + "px";
-              el.style.paddingInlineEnd = style.padding.end + "px";
-              el.style.fontSize = style.fontSize + "px";
+              if (this.ignoreDir) {
+                el.style.marginLeft = style.marginStart + 'px';
+                el.style.paddingLeft = style.padding.start + 'px';
+                el.style.paddingRight = style.padding.end + 'px';
+              } else {
+                el.style.marginInlineStart = style.marginStart + 'px';
+                el.style.paddingInlineStart = style.padding.start + 'px';
+                el.style.paddingInlineEnd = style.padding.end + 'px';
+              }
+              el.style.fontSize = style.fontSize + 'px';
               setStyleId(el, style.id);
               this.observerStart();
             },
@@ -1047,9 +1054,9 @@
              * @private
              */
             fontFit: function fontFit(text, space) {
-              var opts = arguments[2] === undefined ? {} : arguments[2];
+              var opts = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
 
-              debug("font fit:", text, space, opts);
+              debug('font fit:', text, space, opts);
 
               var fontFitArgs = {
                 font: TITLE_FONT,
@@ -1081,7 +1088,7 @@
               });
 
               this.observing = true;
-              debug("observer started");
+              debug('observer started');
             },
 
             /**
@@ -1097,7 +1104,7 @@
               this.observer.disconnect();
 
               this.observing = false;
-              debug("observer stopped");
+              debug('observer stopped');
             },
 
             /**
@@ -1109,7 +1116,7 @@
             onResize: function onResize(e) {
               var _this5 = this;
 
-              debug("onResize", this._resizeThrottlingId);
+              debug('onResize', this._resizeThrottlingId);
 
               if (this._resizeThrottlingId !== null) {
                 return;
@@ -1138,7 +1145,7 @@
              * @private
              */
             onMutation: function onMutation(mutations) {
-              debug("on mutation", mutations);
+              debug('on mutation', mutations);
               if (!this.pending.runFontFitSoon) {
                 this.runFontFit();
               }
@@ -1162,7 +1169,7 @@
                 end: end
               };
 
-              debug("get title space", result);
+              debug('get title space', result);
               return result;
             },
 
@@ -1180,7 +1187,7 @@
             getWidth: function getWidth() {
               var value = this.notFlush ? this.clientWidth : window.innerWidth;
 
-              debug("get width", value);
+              debug('get width', value);
               return value;
             },
 
@@ -1209,9 +1216,9 @@
             onActionButtonClick: function onActionButtonClick() {
               var _this6 = this;
 
-              debug("action button click");
+              debug('action button click');
               var config = { detail: { type: this.action } };
-              var e = new CustomEvent("action", config);
+              var e = new CustomEvent('action', config);
               setTimeout(function () {
                 return _this6.dispatchEvent(e);
               });
@@ -1230,7 +1237,7 @@
               var start = this.titleStart;
               var end = this.titleEnd;
               var marginStart = end - start;
-              debug("get title margin start", marginStart);
+              debug('get title margin start', marginStart);
               return marginStart;
             },
 
@@ -1248,7 +1255,7 @@
 
               for (var i = 0; i < l; i++) {
                 var el = children[i];
-                if (el.tagName === "H1") {
+                if (el.tagName === 'H1') {
                   break;
                 }
                 if (!contributesToLayout(el)) {
@@ -1278,7 +1285,7 @@
 
               for (var i = children.length - 1; i >= 0; i--) {
                 var el = children[i];
-                if (el.tagName === "H1") {
+                if (el.tagName === 'H1') {
                   break;
                 }
                 if (!contributesToLayout(el)) {
@@ -1316,7 +1323,7 @@
                 return prev + width;
               }, 0);
 
-              debug("sum button widths", buttons, sum);
+              debug('sum button widths', buttons, sum);
               return sum;
             },
 
@@ -1339,39 +1346,39 @@
                   if (action === this._action) {
                     return;
                   }
-                  this.setAttr("action", action);
+                  this.setAttr('action', action);
                   this._action = action;
                 }
               },
 
               titleStart: {
                 get: function get() {
-                  debug("get title-start");
-                  if ("_titleStart" in this) {
+                  debug('get title-start');
+                  if ('_titleStart' in this) {
                     return this._titleStart;
                   }
                   var buttons = this.getButtonsBeforeTitle();
                   var value = this.sumButtonWidths(buttons);
-                  debug("get title-start", buttons, value);
+                  debug('get title-start', buttons, value);
                   return value;
                 },
 
                 set: function set(value) {
-                  debug("set title-start", value);
+                  debug('set title-start', value);
                   value = parseInt(value, 10);
                   if (value === this._titleStart || isNaN(value)) {
                     return;
                   }
-                  this.setAttr("title-start", value);
+                  this.setAttr('title-start', value);
                   this._titleStart = value;
-                  debug("set");
+                  debug('set');
                 }
               },
 
               titleEnd: {
                 get: function get() {
-                  debug("get title-end");
-                  if ("_titleEnd" in this) {
+                  debug('get title-end');
+                  if ('_titleEnd' in this) {
                     return this._titleEnd;
                   }
                   var buttons = this.getButtonsAfterTitle();
@@ -1379,12 +1386,12 @@
                 },
 
                 set: function set(value) {
-                  debug("set title-end", value);
+                  debug('set title-end', value);
                   value = parseInt(value, 10);
                   if (value === this._titleEnd || isNaN(value)) {
                     return;
                   }
-                  this.setAttr("title-end", value);
+                  this.setAttr('title-end', value);
                   this._titleEnd = value;
                 }
               },
@@ -1394,8 +1401,8 @@
                   return this._noFontFit || false;
                 },
                 set: function set(value) {
-                  debug("set no-font-fit", value);
-                  value = !!(value || value === "");
+                  debug('set no-font-fit', value);
+                  value = !!(value || value === '');
 
                   if (value === this.noFontFit) {
                     return;
@@ -1403,15 +1410,39 @@
                   this._noFontFit = value;
 
                   if (value) {
-                    this.setAttr("no-font-fit", "");
+                    this.setAttr('no-font-fit', '');
                   } else {
-                    this.removeAttr("no-font-fit");
+                    this.removeAttr('no-font-fit');
+                  }
+                }
+              },
+
+              // The [ignore-dir] attribute can be used to force the older behavior of
+              // gaia-header, where the whole header is always displayed in LTR mode.
+              ignoreDir: {
+                get: function get() {
+                  return this._ignoreDir || false;
+                },
+                set: function set(value) {
+                  debug('set ignore-dir', value);
+                  value = !!(value || value === '');
+
+                  if (value === this.ignoreDir) {
+                    return;
+                  }
+                  this._ignoreDir = value;
+                  this.dirObserver = !value;
+
+                  if (value) {
+                    this.setAttr('ignore-dir', '');
+                  } else {
+                    this.removeAttr('ignore-dir');
                   }
                 }
               }
             },
 
-            template: "<div class=\"inner\">\n    <button class=\"action-button\">\n      <content select=\"[l10n-action]\"></content>\n    </button>\n    <content></content>\n  </div>\n\n  <style>\n\n  :host {\n    display: block;\n    -moz-user-select: none;\n\n    --gaia-header-button-color:\n      var(--header-button-color,\n      var(--header-color,\n      var(--link-color,\n      inherit)));\n  }\n\n  /**\n   * [hidden]\n   */\n\n  :host[hidden] {\n    display: none;\n  }\n\n  /** Reset\n   ---------------------------------------------------------*/\n\n  ::-moz-focus-inner { border: 0; }\n\n  /** Inner\n   ---------------------------------------------------------*/\n\n  .inner {\n    display: flex;\n    min-height: 50px;\n    -moz-user-select: none;\n\n    background:\n      var(--header-background,\n      var(--background,\n      #fff));\n  }\n\n  /** Action Button\n   ---------------------------------------------------------*/\n\n  /**\n   * 1. Hidden by default\n   */\n\n  .action-button {\n    position: relative;\n\n    display: none; /* 1 */\n    width: 50px;\n    font-size: 30px;\n    margin: 0;\n    padding: 0;\n    border: 0;\n    outline: 0;\n\n    align-items: center;\n    background: none;\n    cursor: pointer;\n    transition: opacity 200ms 280ms;\n    color:\n      var(--header-action-button-color,\n      var(--header-icon-color,\n      var(--gaia-header-button-color)));\n  }\n\n  /**\n   * [action=back]\n   * [action=menu]\n   * [action=close]\n   *\n   * 1. For icon vertical-alignment\n   */\n\n  [action=back] .action-button,\n  [action=menu] .action-button,\n  [action=close] .action-button {\n    display: flex; /* 1 */\n  }\n\n  /**\n   * :active\n   */\n\n  .action-button:active {\n    transition: none;\n    opacity: 0.2;\n  }\n\n  /** Action Button Icon\n   ---------------------------------------------------------*/\n\n  .action-button:before {\n    font-family: 'gaia-icons';\n    font-style: normal;\n    text-rendering: optimizeLegibility;\n    font-weight: 500;\n  }\n\n  [action=close] .action-button:before { content: 'close' }\n  [action=menu] .action-button:before { content: 'menu' }\n\n  [action=back]:-moz-dir(ltr) .action-button:before { content: 'back' }\n  [action=back]:-moz-dir(rtl) .action-button:before { content: 'forward' }\n\n  /** Action Button Icon\n   ---------------------------------------------------------*/\n\n  /**\n   * 1. To enable vertical alignment.\n   */\n\n  .action-button:before {\n    display: block;\n  }\n\n  /** Action Button Text\n   ---------------------------------------------------------*/\n\n  /**\n   * To provide custom localized content for\n   * the action-button, we allow the user\n   * to provide an element with the class\n   * .l10n-action. This node is then\n   * pulled inside the real action-button.\n   *\n   * Example:\n   *\n   *   <gaia-header action=\"back\">\n   *     <span l10n-action aria-label=\"Back\">Localized text</span>\n   *     <h1>title</h1>\n   *   </gaia-header>\n   */\n\n  ::content [l10n-action] {\n    position: absolute;\n    left: 0;\n    top: 0;\n    width: 100%;\n    height: 100%;\n    font-size: 0;\n  }\n\n  /** Title\n   ---------------------------------------------------------*/\n\n  /**\n   * 1. Vertically center text. We can't use flexbox\n   *    here as it breaks text-overflow ellipsis\n   *    without an inner div.\n   */\n\n  ::content h1 {\n    flex: 1;\n    margin: 0;\n    padding: 0;\n    overflow: hidden;\n\n    white-space: nowrap;\n    text-overflow: ellipsis;\n    text-align: center;\n    line-height: 50px; /* 1 */\n    font-weight: 300;\n    font-style: italic;\n    font-size: 24px;\n\n    color:\n      var(--header-title-color,\n      var(--header-color,\n      var(--title-color,\n      var(--text-color,\n      inherit))));\n  }\n\n  /** Buttons\n   ---------------------------------------------------------*/\n\n  ::content a,\n  ::content button {\n    position: relative;\n    z-index: 1;\n    box-sizing: border-box;\n    display: flex;\n    width: auto;\n    height: auto;\n    min-width: 50px;\n    margin: 0;\n    padding: 0 10px;\n    outline: 0;\n    border: 0;\n\n    font-size: 14px;\n    line-height: 1;\n    align-items: center;\n    justify-content: center;\n    text-decoration: none;\n    text-align: center;\n    background: none;\n    border-radius: 0;\n    font-style: italic;\n    cursor: pointer;\n    transition: opacity 200ms 280ms;\n    color: var(--gaia-header-button-color);\n  }\n\n  /**\n   * :active\n   */\n\n  ::content a:active,\n  ::content button:active {\n    transition: none;\n    opacity: 0.2;\n  }\n\n  /**\n   * [hidden]\n   */\n\n  ::content a[hidden],\n  ::content button[hidden] {\n    display: none;\n  }\n\n  /**\n   * [disabled]\n   */\n\n  ::content a[disabled],\n  ::content button[disabled] {\n    pointer-events: none;\n    color: var(--header-disabled-button-color);\n  }\n\n  /** Icon Buttons\n   ---------------------------------------------------------*/\n\n  /**\n   * Icons are a different color to text\n   */\n\n  ::content .icon,\n  ::content [data-icon] {\n    color:\n      var(--header-icon-color,\n      var(--gaia-header-button-color));\n  }\n\n  /**\n   * If users want their action button\n   * to be in the component's light-dom\n   * they can add an .action class\n   * to make it look like the\n   * shadow action button.\n   */\n\n  ::content .action {\n    color:\n      var(--header-action-button-color,\n      var(--header-icon-color,\n      var(--gaia-header-button-color)));\n  }\n\n  /**\n   * [data-icon]:empty\n   *\n   * Icon buttons with no textContent,\n   * should always be 50px.\n   *\n   * This is to prevent buttons being\n   * larger than they should be before\n   * icon-font has loaded.\n   */\n\n  ::content [data-icon]:empty {\n    width: 50px;\n  }\n\n  </style>",
+            template: "<div class=\"inner\">\n    <button class=\"action-button\">\n      <content select=\"[l10n-action]\"></content>\n    </button>\n    <content></content>\n  </div>\n\n  <style>\n\n  :host {\n    display: block;\n    -moz-user-select: none;\n\n    --gaia-header-button-color:\n      var(--header-button-color,\n      var(--header-color,\n      var(--link-color,\n      inherit)));\n  }\n\n  /**\n   * [hidden]\n   */\n\n  :host[hidden] {\n    display: none;\n  }\n\n  /** Reset\n   ---------------------------------------------------------*/\n\n  ::-moz-focus-inner { border: 0; }\n\n  /** Inner\n   ---------------------------------------------------------*/\n\n  .inner {\n    display: flex;\n    min-height: 50px;\n    -moz-user-select: none;\n\n    background:\n      var(--header-background,\n      var(--background,\n      #fff));\n  }\n\n  /** Action Button\n   ---------------------------------------------------------*/\n\n  /**\n   * 1. Hidden by default\n   */\n\n  .action-button {\n    position: relative;\n\n    display: none; /* 1 */\n    width: 50px;\n    font-size: 30px;\n    margin: 0;\n    padding: 0;\n    border: 0;\n    outline: 0;\n\n    align-items: center;\n    background: none;\n    cursor: pointer;\n    transition: opacity 200ms 280ms;\n    color:\n      var(--header-action-button-color,\n      var(--header-icon-color,\n      var(--gaia-header-button-color)));\n  }\n\n  /**\n   * [action=back]\n   * [action=menu]\n   * [action=close]\n   *\n   * 1. For icon vertical-alignment\n   */\n\n  [action=back] .action-button,\n  [action=menu] .action-button,\n  [action=close] .action-button {\n    display: flex; /* 1 */\n  }\n\n  /**\n   * :active\n   */\n\n  .action-button:active {\n    transition: none;\n    opacity: 0.2;\n  }\n\n  /** Action Button Icon\n   ---------------------------------------------------------*/\n\n  .action-button:before {\n    font-family: 'gaia-icons';\n    font-style: normal;\n    text-rendering: optimizeLegibility;\n    font-weight: 500;\n  }\n\n  [action=close] .action-button:before { content: 'close' }\n  [action=menu] .action-button:before { content: 'menu' }\n\n  [action=back]:-moz-dir(ltr) .action-button:before { content: 'back' }\n  [action=back]:-moz-dir(rtl) .action-button:before { content: 'forward' }\n\n  /** Action Button Icon\n   ---------------------------------------------------------*/\n\n  /**\n   * 1. To enable vertical alignment.\n   */\n\n  .action-button:before {\n    display: block;\n  }\n\n  /** Action Button Text\n   ---------------------------------------------------------*/\n\n  /**\n   * To provide custom localized content for\n   * the action-button, we allow the user\n   * to provide an element with the class\n   * .l10n-action. This node is then\n   * pulled inside the real action-button.\n   *\n   * Example:\n   *\n   *   <gaia-header action=\"back\">\n   *     <span l10n-action aria-label=\"Back\">Localized text</span>\n   *     <h1>title</h1>\n   *   </gaia-header>\n   */\n\n  ::content [l10n-action] {\n    position: absolute;\n    left: 0;\n    top: 0;\n    width: 100%;\n    height: 100%;\n    font-size: 0;\n  }\n\n  /** Title\n   ---------------------------------------------------------*/\n\n  /**\n   * 1. Vertically center text. We can't use flexbox\n   *    here as it breaks text-overflow ellipsis\n   *    without an inner div.\n   */\n\n  ::content h1 {\n    flex: 1;\n    margin: 0;\n    padding: 0;\n    overflow: hidden;\n\n    white-space: nowrap;\n    text-overflow: ellipsis;\n    text-align: center;\n    line-height: 50px; /* 1 */\n    font-weight: 300;\n    font-style: italic;\n    font-size: 24px;\n\n    color:\n      var(--header-title-color,\n      var(--header-color,\n      var(--title-color,\n      var(--text-color,\n      inherit))));\n  }\n\n  /**\n   * [ignore-dir]\n   *\n   * When the <gaia-header> component has an [ignore-dir] attribute, header\n   * direction is forced to LTR but we still want the <h1> text to be reversed\n   * so that strings like '1 selected' become 'selected 1'.\n   *\n   * When we're happy for <gaia-header> to be fully RTL responsive we won't need\n   * these rules anymore, but this depends on all Gaia apps being ready.\n   *\n   * This should be safe to remove when bug 1179459 lands.\n   */\n\n  :host[ignore-dir] {\n    direction: ltr;\n  }\n\n  :host[ignore-dir]:-moz-dir(rtl) h1 {\n    direction: rtl;\n  }\n\n  /** Buttons\n   ---------------------------------------------------------*/\n\n  ::content a,\n  ::content button {\n    position: relative;\n    z-index: 1;\n    box-sizing: border-box;\n    display: flex;\n    width: auto;\n    height: auto;\n    min-width: 50px;\n    margin: 0;\n    padding: 0 10px;\n    outline: 0;\n    border: 0;\n\n    font-size: 14px;\n    line-height: 1;\n    align-items: center;\n    justify-content: center;\n    text-decoration: none;\n    text-align: center;\n    background: none;\n    border-radius: 0;\n    font-style: italic;\n    cursor: pointer;\n    transition: opacity 200ms 280ms;\n    color: var(--gaia-header-button-color);\n  }\n\n  /**\n   * :active\n   */\n\n  ::content a:active,\n  ::content button:active {\n    transition: none;\n    opacity: 0.2;\n  }\n\n  /**\n   * [hidden]\n   */\n\n  ::content a[hidden],\n  ::content button[hidden] {\n    display: none;\n  }\n\n  /**\n   * [disabled]\n   */\n\n  ::content a[disabled],\n  ::content button[disabled] {\n    pointer-events: none;\n    color: var(--header-disabled-button-color);\n  }\n\n  /** Icon Buttons\n   ---------------------------------------------------------*/\n\n  /**\n   * Icons are a different color to text\n   */\n\n  ::content .icon,\n  ::content [data-icon] {\n    color:\n      var(--header-icon-color,\n      var(--gaia-header-button-color));\n  }\n\n  /**\n   * If users want their action button\n   * to be in the component's light-dom\n   * they can add an .action class\n   * to make it look like the\n   * shadow action button.\n   */\n\n  ::content .action {\n    color:\n      var(--header-action-button-color,\n      var(--header-icon-color,\n      var(--gaia-header-button-color)));\n  }\n\n  /**\n   * [data-icon]:empty\n   *\n   * Icon buttons with no textContent,\n   * should always be 50px.\n   *\n   * This is to prevent buttons being\n   * larger than they should be before\n   * icon-font has loaded.\n   */\n\n  ::content [data-icon]:empty {\n    width: 50px;\n  }\n\n  </style>",
 
             // Test hook
             nextTick: nextTick
@@ -1433,7 +1464,7 @@
            * @return {Boolean}
            */
           function contributesToLayout(el) {
-            return el.localName !== "style" && !el.hasAttribute("l10n-action");
+            return el.localName !== 'style' && !el.hasAttribute('l10n-action');
           }
 
           /**
@@ -1483,14 +1514,14 @@
               } };
           }
         });
-      })(typeof define == "function" && define.amd ? define : (function (n, w) {
-        "use strict";return typeof module == "object" ? function (c) {
+      })(typeof define == 'function' && define.amd ? define : (function (n, w) {
+        'use strict';return typeof module == 'object' ? function (c) {
           c(require, exports, module);
         } : function (c) {
           var m = { exports: {} };c(function (n) {
             return w[n];
           }, m.exports, m);w[n] = m.exports;
         };
-      })("gaia-header", this));
+      })('gaia-header', this));
     }, { "font-fit": 1, "gaia-component": 2, "gaia-icons": 3 }] }, {}, [4])(4);
 });

--- a/index.html
+++ b/index.html
@@ -36,23 +36,27 @@
   <gaia-theme-selector></gaia-theme-selector>
 
   <gaia-header action="back">
-    <h1>Keyboard Settings</h1>
+    <h1>Keyboard Settings <bdi>(1)</bdi></h1>
   </gaia-header>
 
   <gaia-header action="back" dir="ltr">
-    <h1><bdi>With dir="ltr"</bdi></h1>
+    <h1><bdi>With [dir="ltr"]</bdi> <bdi>(1)</bdi></h1>
   </gaia-header>
 
   <gaia-header action="back" dir="rtl">
-    <h1><bdi>With dir="rtl"</bdi></h1>
+    <h1><bdi>With [dir="rtl"]</bdi> <bdi>(1)</bdi></h1>
+  </gaia-header>
+
+  <gaia-header action="back" ignore-dir>
+    <h1><bdi>With [ignore-dir]</bdi> <bdi>(1)</bdi></h1>
   </gaia-header>
 
   <gaia-header action="menu">
-    <h1>Action 'menu'</h1>
+    <h1><bdi>Action “menu”</bdi></h1>
   </gaia-header>
 
   <gaia-header action="close">
-    <h1>Action 'close'</h1>
+    <h1><bdi>Action “close”</bdi></h1>
   </gaia-header>
 
   <gaia-header action="close">


### PR DESCRIPTION
Enables an `ignoreDir` attribute to preserve the gaia-header v0.8.0 behavior, where the whole component is displayed in LTR but the title content direction follows the document direction.

@wilsonpage wdyt?